### PR TITLE
Add basic packed encoding serializer

### DIFF
--- a/contracts/Serializer.sol
+++ b/contracts/Serializer.sol
@@ -48,6 +48,8 @@ struct LightBlock {
     Commit lastCommit;
 }
 
+/// @notice Basic packed encoding serializer.
+/// Uses abi.encodePacked format: https://solidity.readthedocs.io/en/v0.6.12/abi-spec.html#non-standard-packed-mode
 library Serializer {
     using Serializer for Header;
     using Serializer for Signature;

--- a/contracts/Serializer.sol
+++ b/contracts/Serializer.sol
@@ -42,6 +42,7 @@ struct Commit {
 }
 
 /// @notice Bare minimim block data. Only contains the block header and commit.
+/// @dev https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#block
 struct LightBlock {
     Header header;
     Commit lastCommit;
@@ -53,10 +54,6 @@ library Serializer {
     using Serializer for CommitSig;
     using Serializer for Commit;
     using Serializer for LightBlock;
-
-    ////////////////////////////////////
-    // Objects
-    ////////////////////////////////////
 
     function serialize(Header memory obj) internal pure returns (bytes memory) {
         return

--- a/contracts/Serializer.sol
+++ b/contracts/Serializer.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.6.0 <8.0.0;
+pragma experimental ABIEncoderV2;
+
+/// @notice Remote chain block header.
+/// @dev https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#header
+struct Header {
+    uint64 height;
+    uint64 timestamp;
+    bytes32 lastBlockID;
+    bytes32 lastCommitRoot;
+    bytes32 consensusRoot;
+    bytes32 stateCommitment;
+    bytes32 availableDataRoot;
+    bytes32 proposerAddress; // Note: this needs to be converted to a 20-byte address when used
+}
+
+/// @notice Compact ECDSA signature.
+/// @dev https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#signature
+struct Signature {
+    bytes32 r;
+    bytes32 vs;
+}
+
+/// @notice Tendermint signature.
+/// @dev https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#commitsig
+struct CommitSig {
+    uint8 blockIDFlag;
+    bytes32 validatorAddress; // Note: this needs to be converted to a 20-byte address when used
+    uint64 timestamp;
+    Signature signature;
+}
+
+/// @notice Tendermint commit (list of signatures).
+/// @dev https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#commit
+struct Commit {
+    uint64 height;
+    uint64 round;
+    uint64 blockID;
+    uint8 signaturesCount;
+    CommitSig[] signatures;
+}
+
+/// @notice Bare minimim block data. Only contains the block header and commit.
+struct LightBlock {
+    Header header;
+    Commit lastCommit;
+}
+
+library Serializer {
+    using Serializer for Header;
+    using Serializer for Signature;
+    using Serializer for CommitSig;
+    using Serializer for Commit;
+    using Serializer for LightBlock;
+
+    ////////////////////////////////////
+    // Objects
+    ////////////////////////////////////
+
+    function serialize(Header memory obj) internal pure returns (bytes memory) {
+        return
+            abi.encodePacked(
+                obj.height,
+                obj.timestamp,
+                obj.lastBlockID,
+                obj.lastCommitRoot,
+                obj.consensusRoot,
+                obj.stateCommitment,
+                obj.availableDataRoot,
+                obj.proposerAddress
+            );
+    }
+
+    function serialize(Signature memory obj) internal pure returns (bytes memory) {
+        return abi.encodePacked(obj.r, obj.vs);
+    }
+
+    function serialize(CommitSig memory obj) internal pure returns (bytes memory) {
+        return abi.encodePacked(obj.blockIDFlag, obj.validatorAddress, obj.timestamp, obj.signature.serialize());
+    }
+
+    function serialize(Commit memory obj) internal pure returns (bytes memory) {
+        // TODO serialize sigs
+        return abi.encodePacked(obj.height, obj.round, obj.blockID, obj.signaturesCount);
+    }
+
+    function serialize(LightBlock memory obj) internal pure returns (bytes memory) {
+        return abi.encodePacked(obj.header.serialize(), obj.lastCommit.serialize());
+    }
+}

--- a/contracts/Tendermint-ORU.sol
+++ b/contracts/Tendermint-ORU.sol
@@ -4,6 +4,8 @@ pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 
+import "./Serializer.sol";
+
 /// @notice Submission of remote chain block header.
 struct HeaderSubmission {
     // Block header
@@ -14,50 +16,6 @@ struct HeaderSubmission {
     uint256 blockNumber;
     // Simple hash of previous block's commit in ABI encoded format
     bytes32 lastCommitHash;
-}
-
-/// @notice Remote chain block header.
-/// @dev https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#header
-struct Header {
-    uint64 height;
-    uint64 timestamp;
-    bytes32 lastBlockID;
-    bytes32 lastCommitRoot;
-    bytes32 consensusRoot;
-    bytes32 stateCommitment;
-    bytes32 availableDataRoot;
-    bytes32 proposerAddress; // Note: this needs to be converted to a 20-byte address when used
-}
-
-/// @notice Compact ECDSA signature.
-/// @dev https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#signature
-struct Signature {
-    bytes32 r;
-    bytes32 vs;
-}
-
-/// @notice Tendermint signature.
-/// @dev https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#commitsig
-struct CommitSig {
-    uint8 blockIDFlag;
-    bytes32 validatorAddress; // Note: this needs to be converted to a 20-byte address when used
-    uint64 timestamp;
-    Signature signature;
-}
-
-/// @notice Tendermint commit (list of signatures).
-/// @dev https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#commit
-struct Commit {
-    uint64 height;
-    uint64 round;
-    uint64 blockID;
-    CommitSig[] signatures;
-}
-
-/// @notice Bare minimim block data. Only contains the block header and commit.
-struct LightBlock {
-    Header header;
-    Commit lastCommit;
 }
 
 /// @title Optimistic rollup of a remote chain's Tendermint consensus.

--- a/contracts/Tendermint-ORU.sol
+++ b/contracts/Tendermint-ORU.sol
@@ -99,7 +99,7 @@ contract Tendermint_ORU {
     ////////////////////////////////////
 
     /// @notice Submit a new bare block, placing a bond.
-    function submitBlock(LightBlock calldata lightBlock, bytes32 prevSubmissionHash) external payable {
+    function submitBlock(LightBlock memory lightBlock, bytes32 prevSubmissionHash) external payable {
         // Must send _bondSize ETH to submit a block
         require(msg.value == _bondSize);
         // Previous block header hash must be the tip
@@ -110,7 +110,7 @@ contract Tendermint_ORU {
         require(lightBlock.header.height == SafeMath.add(_headerHeights[prevSubmissionHash], 1));
 
         // Take simple hash of commit for previous block
-        bytes32 lastCommitHash = keccak256(abi.encode(lightBlock.lastCommit));
+        bytes32 lastCommitHash = keccak256(lightBlock.lastCommit.serialize());
 
         // Serialize header
         bytes memory serializedHeader = lightBlock.header.serialize();
@@ -139,7 +139,7 @@ contract Tendermint_ORU {
         bytes32 headerHash,
         HeaderSubmission calldata headerSubmission,
         HeaderSubmission calldata tipSubmission,
-        Commit calldata commit
+        Commit memory commit
     ) external {
         // Check submission against storage
         bytes32 headerSubmissionHash = keccak256(abi.encode(headerSubmission));

--- a/contracts/Tendermint-ORU.sol
+++ b/contracts/Tendermint-ORU.sol
@@ -20,6 +20,12 @@ struct HeaderSubmission {
 
 /// @title Optimistic rollup of a remote chain's Tendermint consensus.
 contract Tendermint_ORU {
+    using Serializer for Header;
+    using Serializer for Signature;
+    using Serializer for CommitSig;
+    using Serializer for Commit;
+    using Serializer for LightBlock;
+
     ////////////////////////////////////
     // Events
     ////////////////////////////////////
@@ -106,8 +112,8 @@ contract Tendermint_ORU {
         // Take simple hash of commit for previous block
         bytes32 lastCommitHash = keccak256(abi.encode(lightBlock.lastCommit));
 
-        // TODO serialize header
-        bytes memory serializedHeader;
+        // Serialize header
+        bytes memory serializedHeader = lightBlock.header.serialize();
 
         // Hash serialized header
         bytes32 headerHash = keccak256(serializedHeader);

--- a/test/Tendermint-ORU.js
+++ b/test/Tendermint-ORU.js
@@ -43,6 +43,7 @@ contract("Tendermint_ORU", async (accounts) => {
             height: 1,
             round: 0,
             blockID: EMPTY_HASH,
+            signaturesCount: 0,
             signatures: [],
           },
         },


### PR DESCRIPTION
A trivial encoding that just takes the bytes (big-endian for ints) and concatenates them. Completely schema-less; no struct or field IDs, no varints, no implicit variable lengths. This happens to be what `abi.encodePacked()` does under the hood as a happy coincidence: https://solidity.readthedocs.io/en/v0.6.12/abi-spec.html#non-standard-packed-mode